### PR TITLE
Fix "lets" apostrophe

### DIFF
--- a/_posts/2019-03-18-degenerate-view-controller-state.md
+++ b/_posts/2019-03-18-degenerate-view-controller-state.md
@@ -305,7 +305,7 @@ class ViewController: UIViewController {
 }
 ```
 
-The view controller sits quietly and let's concrete states apply their own policies upon it. It comes not without a price: we had to leak encapsulation and make `items` property public. Such tradeoff is common when implementing *state design pattern* and is usually acceptable.
+The view controller sits quietly and lets concrete states apply their own policies upon it. It comes not without a price: we had to leak encapsulation and make `items` property public. Such tradeoff is common when implementing *state design pattern* and is usually acceptable.
 
 ### Conclusion
 


### PR DESCRIPTION
In this context, lets should be written without an apostrophe.
(Excellent post, BTW!)